### PR TITLE
How Decred is Unique Revamp - Script Re-Write (15)

### DIFF
--- a/decredUnique/decredUnique_vo.md
+++ b/decredUnique/decredUnique_vo.md
@@ -1,6 +1,7 @@
 ## How Decred Is Unique
 ### Voice Over Script
-Decred is a cryptocurrency which builds upon the strengths of bitcoin. To see how Decred is unique, let's compare the two.
+
+Decred is a cryptocurrency which builds upon the strengths of Bitcoin. To see how Decred is unique, let's compare the two.
 
 Both Bitcoin and Decred have a 21 million coin supply cap.
 
@@ -8,23 +9,27 @@ Here's where things get interesting.
 
 Bitcoin's mining subsidy is reduced by 50 percent every 4 years as shown by this stepped graph.
 
-Decred reduces its mining subsidy smoothly and gradually by 1% evry 21 days as shown by this curve.
+Decred reduces its mining subsidy smoothly and gradually by 1% every 21 days as shown by this curve.
 
-New Bitcoin blocks are found and broadcast by proof-of-work miners, who also recieve 100% of the Bitcoin reward. This gives miners all the power, leaving users without a way to coordinate and change the rules regarding what blocks are considered valid. This leaves open the possibility for hard forks in the chain.
+New Bitcoin blocks are found and broadcast by proof-of-work miners, who also recieve 100% of the Bitcoin block reward. This gives miners all the power, leaving users without a way to coordinate and change the rules regarding what constitutes a valid block. This leaves open the possibility for hard forks in the chain.
 
-Decred aims to improve on this by implementing a system of checks and balances on its proof-of-work miners, giving its users more say in Decred's development.
+Decred improves on this by utilizing a hybrid proof-of-work - proof-of-stake system. Proof-of-work miners recieve 60% of the Decred block reward for finding blocks, and Proof-of-stake Voters recieve 30% for keeping miners in check.
 
 It works like this:
 
-Once a new decred block is found by a proof-of-work miner, the validity of that block is decided by a consensus vote cast by 5 stake voters. If a majority vote deeming the block valid is not achieved, the newly found block is immediately rejected by the network. If a block is deemed valid, then the new minted Decred coins are split 60-30. 60% goes to the proof-of-work miners for finding the block and 30% goes to the stake voters for doing their part to secure the chain. Decred's hybridized mining system makes sure that its chain will never split.
+Every 5 minutes a new Decred block is found by a proof-of-work miner. Contained in each block are 5 votes cast by proof-of-stake voters. These votes are used to check the miner behaviour of the previous block.
+
+If a majority deems the pending block unwanted, the miner is stripped of their portion of the block reward as punishment for breaking the rules.
+
+By allowing the rejection of unwanted blocks Decred's hybrid system serves to stop chain-splits and miner attacks.
 
 The differences don't stop there.
 
-10% of every Decred block is placed in the Decred development fund. The development fund makes Decred a self-funded open source project with no need outside capital or an ICO.
+10% of the Decred block reward is placed in the network fund. The network fund makes Decred a self-funded open source project with no need for outside capital or an ICO.
 
-How the development fund is spen is determined by the users. Through the project proposal website, users get to vote on ideas to improve the network and select the development team to complete them.
+How the network fund is spent is determined by the users. Through the Decred proposal system stakeholders get to vote to determine which community sourced projects recieve funding.
 
-Decred is controlled by the community. To join the Decred community, go to Decred.org to download the user software for you rplatoform and get Decred on exhanges such as Bittrex and Poloniex.
+Decred is controlled by the stakeholders. To become a stakeholder go to Decred.org to download Decrediton for your platform and buy Decred on one of the many supporting exchanges.
 
-Decred; Decentralized Credits.
+Decred; Decentralized Credit.
 


### PR DESCRIPTION
Refers to issue https://github.com/raedahgroup/video-production/issues/15

- fixed some typos
- some grammar fixes
- correct 'block voting' sequence
- correct proposal site sequence
- vocab changes 
    - development fund -> network fund, 
    - stake voter(ing) -> PoS voter(ing) 
    - community -> stakeholders
- mention block reward split before block voting sequence
- mention Decrediton and say "supporting exchanges" instead of "Bittrex and Poloniex"
